### PR TITLE
Fix Android SSDP Issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-discovery",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Simple plugin to get any SSDP / UPnP / DLNA service on a local network",
   "cordova": {
     "id": "cordova-plugin-discovery",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-discovery"
-        version="0.2.2">
+        version="0.2.3">
 
   <name>serviceDiscovery</name>
 

--- a/src/android/cordovaSSDP.java
+++ b/src/android/cordovaSSDP.java
@@ -74,7 +74,7 @@ public class cordovaSSDP extends CordovaPlugin {
 
     public void search(String service, CallbackContext callbackContext) throws IOException {
         final int SSDP_PORT = 1900;
-        final int SSDP_SEARCH_PORT = 1901;
+        final int SSDP_SEARCH_PORT = 12000;
         final String SSDP_IP = "239.255.255.250";
         int TIMEOUT = 6000;
 
@@ -100,8 +100,9 @@ public class cordovaSSDP extends CordovaPlugin {
         MulticastSocket multicast = null;
         try {
             multicast = new MulticastSocket(null);
+            multicast.setReuseAddress(true);
             multicast.bind(srcAddress);
-            multicast.setTimeToLive(4);
+            multicast.setTimeToLive(10);
             multicast.send(discoveryPacket);
         } finally {
             multicast.disconnect();
@@ -112,7 +113,9 @@ public class cordovaSSDP extends CordovaPlugin {
         DatagramSocket wildSocket = null;
         DatagramPacket receivePacket;
         try {
-            wildSocket = new DatagramSocket(SSDP_SEARCH_PORT);
+            wildSocket = new DatagramSocket(null);
+            wildSocket.setReuseAddress(true);
+            wildSocket.bind(srcAddress);
             wildSocket.setSoTimeout(TIMEOUT);
 
             while (true) {


### PR DESCRIPTION
This PR addresses issues with SSDP discovery for Android using a Samsung Galaxy S9 running Android 9.

Changes:
- Make UDP sockets use `setReuseAddress` to prevent `EADDRINUSE` error
- Increment multicast TTL to 10
- Increase port number from 1901 to 12000
- Update package versioning to `0.2.3`